### PR TITLE
Fix retrieveResponseFromService method

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/network/NetworkConnection.java
+++ b/DataDroid/src/com/foxykeep/datadroid/network/NetworkConnection.java
@@ -157,7 +157,7 @@ public class NetworkConnection {
     public static NetworkConnectionResult retrieveResponseFromService(final String url, final int method,
             final Map<String, String> parameters, final ArrayList<Header> headers) throws IllegalStateException,
             IOException, URISyntaxException, RestClientException {
-        return retrieveResponseFromService(url, method, parameters, null, false);
+        return retrieveResponseFromService(url, method, parameters, headers, false);
     }
 
     /**


### PR DESCRIPTION
[Code Review]
Fix retrieveResponseFromService(String url, int method, Map<String, String> parameters, ArrayList<Header> headers) method : headers were not thrown in the following overload method
