### PR TITLE
Bug: Missing targetSdk and minSdk values

### DIFF
--- a/DataDroid/AndroidManifest.xml
+++ b/DataDroid/AndroidManifest.xml
@@ -3,4 +3,5 @@
       package="com.foxykeep.datadroid"
       android:versionCode="1"
       android:versionName="1.0">
+    <uses-sdk android:targetSdkVersion="8" android:minSdkVersion="8"/>
 </manifest>

--- a/DataDroid/project.properties
+++ b/DataDroid/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-10
+target=android-8


### PR DESCRIPTION
- Add targetSdk and minSdk values in AndroidManifest.xml
- Change build sdk to android-8 in project-properties

8 is required because of AndroidHttpClient. Might be easy to backport the class and use it where current api < 8?
