### PR TITLE
new trigger generation methods to emulate foreign key constraints and

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/provider/util/DatabaseUtil.java
+++ b/DataDroid/src/com/foxykeep/datadroid/provider/util/DatabaseUtil.java
@@ -11,8 +11,7 @@ package com.foxykeep.datadroid.provider.util;
 import android.database.sqlite.SQLiteDatabase;
 
 public class DatabaseUtil {
-
-    /**
+	/**
      * Creates the string used by the database to create an index in a table.
      * This string can be used in the function
      * {@link SQLiteDatabase#execSQL(String)}
@@ -22,7 +21,101 @@ public class DatabaseUtil {
      * @return The index string
      */
     public static String getCreateIndexString(final String tableName, final String columnName) {
-        return "create index " + tableName.toLowerCase() + '_' + columnName + " on " + tableName + " (" + columnName
+        return "create index " + tableName + '_' + columnName + " on " + tableName + " (" + columnName
                 + ");";
+    }
+
+	/**
+	 * Creates the string used by the database to create an trigger that prevents insert
+	 * into the childTable if the foreignKey matching the primaryKey in the parentTable
+	 * does not exist. This prevents the creation orphaned rows in dependent tables.
+     * This string can be used in the function
+     * {@link SQLiteDatabase#execSQL(String)}
+     * 
+	 * @param parentTable The parent table
+	 * @param primaryKey The primary key in the parent table
+	 * @param childTable The dependent table
+	 * @param foreignKey The foreign key in the dependent table
+	 * @return The prevent insert trigger string
+	 */
+	public static String getPreventInsertString(final String parentTable, final String primaryKey, 
+			final String childTable, final String foreignKey) {
+		String triggerName = "pi_" + parentTable + "_" + primaryKey + "_" + childTable + "_"
+				+ foreignKey;
+		return "create trigger " + triggerName + " before insert on [" + childTable
+				+ "] for each row begin select raise(rollback, 'insert on table \"" + childTable
+				+ "\" violates foreign key constraint \"" + triggerName + "\"') where new." + foreignKey
+				+ " is not null and (select " +  primaryKey + " from " + parentTable + " where " + primaryKey
+				+ " = new." + foreignKey + ") is null; end;";
+	}
+
+	/**
+	 * Creates the string used by the database to create an trigger that prevents update
+	 * into the childTable if the foreignKey matching the primaryKey in the parentTable
+	 * does not exist. 
+     * This string can be used in the function
+     * {@link SQLiteDatabase#execSQL(String)}
+     * 
+	 * @param parentTable The parent table
+	 * @param primaryKey The primary key in the parent table
+	 * @param childTable The dependent table
+	 * @param foreignKey The foreign key in the dependent table
+	 * @return The prevent update trigger string
+	 */
+	public static String getPreventUpdateString(final String parentTable, final String primaryKey, 
+			final String childTable, final String foreignKey) {
+		String triggerName = "pu_" + parentTable + "_" + primaryKey + "_" + childTable + "_"
+				+ foreignKey;
+		return "create trigger " + triggerName + " before update on [" + childTable
+				+ "] for each row begin select raise(rollback, 'update on table \"" + childTable
+				+ "\" violates foreign key constraint \"" + triggerName + "\"') where new." + foreignKey
+				+ " is not null and (select " +  primaryKey + " from " + parentTable + " where " + primaryKey
+				+ " = new." + foreignKey + ") is null; end;";
+	}
+
+	/**
+	 * Creates the string used by the database to create an trigger that prevents delete
+	 * of parentTable rows if the childTable has rows in which the foreignKey matches the
+	 * primaryKey. This prevents rows in dependent tabled from being orphaned. DO NOT USE
+	 * WITH getDeleteCascadeString().
+     * This string can be used in the function
+     * {@link SQLiteDatabase#execSQL(String)}
+     * 
+	 * @param parentTable The parent table
+	 * @param primaryKey The primary key in the parent table
+	 * @param childTable The dependent table
+	 * @param foreignKey The foreign key in the dependent table
+	 * @return The prevent update trigger string
+	 */
+	public static String getPreventDeleteString(final String parentTable, final String primaryKey, 
+			final String childTable, final String foreignKey) {
+		String triggerName = "pd_" + parentTable + "_" + primaryKey + "_" + childTable + "_"
+				+ foreignKey;
+		return "create trigger " + triggerName + " before delete on [" + childTable
+				+ "] for each row begin select raise(rollback, 'delete on table \"" + childTable
+				+ "\" violates foreign key constraint \"" + triggerName + "\"') where new." + foreignKey
+				+ " is not null and (select " +  foreignKey + " from " + childTable + " where " + foreignKey
+				+ " = old." + primaryKey + ") is not null; end;";
+	}
+	
+	/**
+	 * Creates the string used by the database to create an trigger that deletes rows in
+	 * the childTable when the foreignKey matching the primaryKey in the parentTable is 
+	 * deleted. This cleans up orphaned rows in dependent tables. DO NOT USE WITH
+	 * getDeleteCascadeString().
+     * This string can be used in the function
+     * {@link SQLiteDatabase#execSQL(String)}
+     * 
+	 * @param parentTable The parent table
+	 * @param primaryKey The primary key in the parent table
+	 * @param childTable The dependent table
+	 * @param foreignKey The foreign key in the dependent table
+	 * @return The prevent update trigger string
+	 */
+	public static String getDeleteCascadeString(final String parentTable, final String primaryKey, 
+			final String childTable, final String foreignKey) {
+		return "create trigger dc_" + parentTable + "_" + primaryKey + "_" + childTable + "_"
+				+ foreignKey + " before delete on [" + parentTable + "] for each row begin delete from " 
+				+ childTable + " where " + childTable + "." + foreignKey + " = old." + primaryKey + "; end;";
     }
 }


### PR DESCRIPTION
- add methods to generate triggers that simulate foreign key constraints since they are unsupported with Android's sqlite version in api < (iirc) 8
- remove call to toLowerCase() on tableName string in getCreateIndexString()
  - it does not specify a locale, [which can lead to weirdness](http://developer.android.com/reference/java/util/Locale.html#default_locale)
  - index names have no lowercase restriction, whats the point of doing this?
  - it's possible, however unlikely and idiotic, that somebody uses tables 'foo' and 'Foo'
