### PR TITLE
Handle getErrorStream() to throw more specific error message from server

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -215,22 +215,18 @@ public final class NetworkConnectionImpl {
             
             String contentEncoding = connection.getHeaderField(CONTENT_ENCODING_HEADER);
 
-            if (responseCode != HttpStatus.SC_OK) {
-                if (responseCode == HttpStatus.SC_MOVED_PERMANENTLY) {
-                    String redirectionUrl = connection.getHeaderField(LOCATION_HEADER);
-                    throw new ConnectionException("New location : " + redirectionUrl,
-                            redirectionUrl);
-                } else {
-                    InputStream errorStream = connection.getErrorStream();
-                    if(errorStream != null){
-                        String error = convertStreamToString(connection.getInputStream(),
-                                contentEncoding != null
-                                && contentEncoding.equalsIgnoreCase("gzip"));
-                        throw new ConnectionException(error, responseCode);
-                    } else {
-                        throw new ConnectionException("Invalid response from server.", responseCode);
-                    }
-                }
+            InputStream errorStream = connection.getErrorStream();
+            if(errorStream != null){
+                String error = convertStreamToString(connection.getInputStream(),
+                        contentEncoding != null
+                        && contentEncoding.equalsIgnoreCase("gzip"));
+                throw new ConnectionException(error, responseCode);
+            } 
+            
+            if (responseCode == HttpStatus.SC_MOVED_PERMANENTLY) {
+                String redirectionUrl = connection.getHeaderField(LOCATION_HEADER);
+                throw new ConnectionException("New location : " + redirectionUrl,
+                        redirectionUrl);
             }
 
             String body = convertStreamToString(connection.getInputStream(),


### PR DESCRIPTION
Fix error handling by looking for getErrorStream instead of throwing an error when status code is different than SC_OK (200).
Some http status codes like 201 should not be considered as error.
