### PR TITLE
Fix Error Handling

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -215,22 +215,18 @@ public final class NetworkConnectionImpl {
             
             String contentEncoding = connection.getHeaderField(CONTENT_ENCODING_HEADER);
 
-            if (responseCode != HttpStatus.SC_OK) {
-                if (responseCode == HttpStatus.SC_MOVED_PERMANENTLY) {
-                    String redirectionUrl = connection.getHeaderField(LOCATION_HEADER);
-                    throw new ConnectionException("New location : " + redirectionUrl,
-                            redirectionUrl);
-                } else {
-                    InputStream errorStream = connection.getErrorStream();
-                    if(errorStream != null){
-                        String error = convertStreamToString(connection.getInputStream(),
-                                contentEncoding != null
-                                && contentEncoding.equalsIgnoreCase("gzip"));
-                        throw new ConnectionException(error, responseCode);
-                    } else {
-                        throw new ConnectionException("Invalid response from server.", responseCode);
-                    }
-                }
+            InputStream errorStream = connection.getErrorStream();
+            if(errorStream != null){
+                String error = convertStreamToString(connection.getInputStream(),
+                        contentEncoding != null
+                        && contentEncoding.equalsIgnoreCase("gzip"));
+                throw new ConnectionException(error, responseCode);
+            } 
+            
+            if (responseCode == HttpStatus.SC_MOVED_PERMANENTLY) {
+                String redirectionUrl = connection.getHeaderField(LOCATION_HEADER);
+                throw new ConnectionException("New location : " + redirectionUrl,
+                        redirectionUrl);
             }
 
             String body = convertStreamToString(connection.getInputStream(),

--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -211,27 +211,27 @@ public final class NetworkConnectionImpl {
             }
 
             int responseCode = connection.getResponseCode();
+            boolean isGzip = contentEncoding != null
+                        && contentEncoding.equalsIgnoreCase("gzip")
             DataDroidLog.d(TAG, "Response code: " + responseCode);
             
             String contentEncoding = connection.getHeaderField(CONTENT_ENCODING_HEADER);
 
-            InputStream errorStream = connection.getErrorStream();
-            if(errorStream != null){
-                String error = convertStreamToString(connection.getInputStream(),
-                        contentEncoding != null
-                        && contentEncoding.equalsIgnoreCase("gzip"));
-                throw new ConnectionException(error, responseCode);
-            } 
-            
             if (responseCode == HttpStatus.SC_MOVED_PERMANENTLY) {
                 String redirectionUrl = connection.getHeaderField(LOCATION_HEADER);
                 throw new ConnectionException("New location : " + redirectionUrl,
                         redirectionUrl);
             }
+            
+            InputStream errorStream = connection.getErrorStream();
+            if(errorStream != null){
+                String error = convertStreamToString(connection.getInputStream(),
+                        isGzip);
+                throw new ConnectionException(error, responseCode);
+            } 
 
             String body = convertStreamToString(connection.getInputStream(),
-                    contentEncoding != null
-                    && contentEncoding.equalsIgnoreCase("gzip"));
+                    isGzip);
 
             if (DataDroidLog.canLog(Log.VERBOSE)) {
                 DataDroidLog.v(TAG, "Response body: ");


### PR DESCRIPTION
Fix error handling by looking for [getErrorStream()](http://developer.android.com/reference/java/net/HttpURLConnection.html#getErrorStream%28%29) instead of throwing an
error when status code is different than [SC_OK](http://developer.android.com/reference/org/apache/http/HttpStatus.html#SC_OK).
