### PR TITLE
Add a delay before stopping the Service

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/service/MultiThreadedIntentService.java
+++ b/DataDroid/src/com/foxykeep/datadroid/service/MultiThreadedIntentService.java
@@ -48,7 +48,7 @@ public abstract class MultiThreadedIntentService extends Service {
 
     private Handler mHandler;
 
-    final Runnable mWorkDoneRunnable = new Runnable() {
+    private final Runnable mWorkDoneRunnable = new Runnable() {
         @Override
         public void run() {
             if (Looper.getMainLooper().getThread() != Thread.currentThread()) {
@@ -145,6 +145,7 @@ public abstract class MultiThreadedIntentService extends Service {
 
         public void run() {
             onHandleIntent(mIntent);
+            mHandler.removeCallbacks(mWorkDoneRunnable);
             mHandler.post(mWorkDoneRunnable);
         }
     }


### PR DESCRIPTION
Prevent the MultiThreadedIntentService from being stopped as soon as there is no task to process. Stopping the Service after a given delay may avoid the instantiation of new Services.
