### PR TITLE
Request.mMemoryCacheDataEnabled is lost if activity is destroyed

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/requestmanager/Request.java
+++ b/DataDroid/src/com/foxykeep/datadroid/requestmanager/Request.java
@@ -602,6 +602,7 @@ public final class Request implements Parcelable {
     // Parcelable management
     private Request(final Parcel in) {
         mRequestType = in.readInt();
+        mMemoryCacheDataEnabled = (in.readByte() == 1);
         in.readStringList(mParamList);
         for (int i = 0, n = in.readInt(); i < n; i++) {
             mTypeList.add(in.readInt());
@@ -617,6 +618,7 @@ public final class Request implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(mRequestType);
+        dest.writeByte((byte) (mMemoryCacheDataEnabled ? 1 : 0));
         dest.writeStringList(mParamList);
         dest.writeInt(mTypeList.size());
         for (int i = 0, length = mTypeList.size(); i < length; i++) {

--- a/DataDroid/src/com/foxykeep/datadroid/requestmanager/Request.java
+++ b/DataDroid/src/com/foxykeep/datadroid/requestmanager/Request.java
@@ -602,7 +602,7 @@ public final class Request implements Parcelable {
     // Parcelable management
     private Request(final Parcel in) {
         mRequestType = in.readInt();
-        mMemoryCacheDataEnabled = (in.readByte() == 1);
+        mMemoryCacheDataEnabled = in.readInt() == 1;
         in.readStringList(mParamList);
         for (int i = 0, n = in.readInt(); i < n; i++) {
             mTypeList.add(in.readInt());
@@ -618,7 +618,7 @@ public final class Request implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(mRequestType);
-        dest.writeByte((byte) (mMemoryCacheDataEnabled ? 1 : 0));
+        dest.writeInt(mMemoryCacheDataEnabled ? 1 : 0);
         dest.writeStringList(mParamList);
         dest.writeInt(mTypeList.size());
         for (int i = 0, length = mTypeList.size(); i < length; i++) {


### PR DESCRIPTION
Response will not be delivered to activity if the activity was destroyed in the meanwhile. Added mMemoryCacheDataEnabled to be saved on disk.
