### PR TITLE
Fix IOException that prevents a ConnectionException from being thrown normally; e.g. when the server responds with a 500 status code.

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -225,8 +225,7 @@ public final class NetworkConnectionImpl {
 
             InputStream errorStream = connection.getErrorStream();
             if (errorStream != null) {
-                String error = convertStreamToString(connection.getInputStream(),
-                        isGzip);
+                String error = convertStreamToString(errorStream,  isGzip);
                 throw new ConnectionException(error, responseCode);
             }
 


### PR DESCRIPTION
... as per http://developer.android.com/reference/java/net/HttpURLConnection.html
