### PR TITLE
Fixes issue #21

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -8,19 +8,6 @@
 
 package com.foxykeep.datadroid.internal.network;
 
-import android.content.Context;
-import android.support.util.Base64;
-import android.util.Log;
-
-import com.foxykeep.datadroid.exception.ConnectionException;
-import com.foxykeep.datadroid.network.NetworkConnection.ConnectionResult;
-import com.foxykeep.datadroid.network.NetworkConnection.Method;
-import com.foxykeep.datadroid.network.UserAgentUtils;
-import com.foxykeep.datadroid.util.DataDroidLog;
-
-import org.apache.http.HttpStatus;
-import org.apache.http.auth.UsernamePasswordCredentials;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,6 +20,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.zip.GZIPInputStream;
 
@@ -43,6 +31,20 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.message.BasicNameValuePair;
+
+import android.content.Context;
+import android.support.util.Base64;
+import android.util.Log;
+
+import com.foxykeep.datadroid.exception.ConnectionException;
+import com.foxykeep.datadroid.network.NetworkConnection.ConnectionResult;
+import com.foxykeep.datadroid.network.NetworkConnection.Method;
+import com.foxykeep.datadroid.network.UserAgentUtils;
+import com.foxykeep.datadroid.util.DataDroidLog;
 
 /**
  * Implementation of the network connection.
@@ -90,7 +92,7 @@ public final class NetworkConnectionImpl {
      * @return The result of the webservice call.
      */
     public static ConnectionResult execute(Context context, String urlValue, Method method,
-            HashMap<String, String> parameterMap, HashMap<String, String> headerMap,
+            List<BasicNameValuePair> parameterMap, HashMap<String, String> headerMap,
             boolean isGzipEnabled, String userAgent, String postText,
             UsernamePasswordCredentials credentials, boolean isSslValidationEnabled) throws
             ConnectionException {
@@ -114,8 +116,8 @@ public final class NetworkConnectionImpl {
 
             StringBuilder paramBuilder = new StringBuilder();
             if (parameterMap != null && !parameterMap.isEmpty()) {
-                for (Entry<String, String> parameter : parameterMap.entrySet()) {
-                    paramBuilder.append(URLEncoder.encode(parameter.getKey(), UTF8_CHARSET));
+                for (BasicNameValuePair parameter : parameterMap) {
+                    paramBuilder.append(URLEncoder.encode(parameter.getName(), UTF8_CHARSET));
                     paramBuilder.append("=");
                     paramBuilder.append(URLEncoder.encode(parameter.getValue(), UTF8_CHARSET));
                     paramBuilder.append("&");
@@ -129,8 +131,8 @@ public final class NetworkConnectionImpl {
 
                 if (parameterMap != null && !parameterMap.isEmpty()) {
                     DataDroidLog.d(TAG, "Parameters:");
-                    for (Entry<String, String> parameter : parameterMap.entrySet()) {
-                        String message = "- " + parameter.getKey() + " = " + parameter.getValue();
+                    for (BasicNameValuePair parameter : parameterMap) {
+                        String message = "- " + parameter.getName() + " = " + parameter.getValue();
                         DataDroidLog.d(TAG, message);
                     }
                 }

--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -8,6 +8,20 @@
 
 package com.foxykeep.datadroid.internal.network;
 
+import android.content.Context;
+import android.support.util.Base64;
+import android.util.Log;
+
+import com.foxykeep.datadroid.exception.ConnectionException;
+import com.foxykeep.datadroid.network.NetworkConnection.ConnectionResult;
+import com.foxykeep.datadroid.network.NetworkConnection.Method;
+import com.foxykeep.datadroid.network.UserAgentUtils;
+import com.foxykeep.datadroid.util.DataDroidLog;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.message.BasicNameValuePair;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,8 +33,8 @@ import java.net.URLEncoder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map.Entry;
 import java.util.zip.GZIPInputStream;
 
@@ -31,20 +45,6 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-
-import org.apache.http.HttpStatus;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.message.BasicNameValuePair;
-
-import android.content.Context;
-import android.support.util.Base64;
-import android.util.Log;
-
-import com.foxykeep.datadroid.exception.ConnectionException;
-import com.foxykeep.datadroid.network.NetworkConnection.ConnectionResult;
-import com.foxykeep.datadroid.network.NetworkConnection.Method;
-import com.foxykeep.datadroid.network.UserAgentUtils;
-import com.foxykeep.datadroid.util.DataDroidLog;
 
 /**
  * Implementation of the network connection.
@@ -80,7 +80,7 @@ public final class NetworkConnectionImpl {
      *            needed.
      * @param url The webservice URL.
      * @param method The request method to use.
-     * @param parameterMap The parameters to add to the request.
+     * @param parameterList The parameters to add to the request.
      * @param headerMap The headers to add to the request.
      * @param isGzipEnabled Whether the request will use gzip compression if available on the
      *            server.
@@ -92,7 +92,7 @@ public final class NetworkConnectionImpl {
      * @return The result of the webservice call.
      */
     public static ConnectionResult execute(Context context, String urlValue, Method method,
-            List<BasicNameValuePair> parameterMap, HashMap<String, String> headerMap,
+            ArrayList<BasicNameValuePair> parameterList, HashMap<String, String> headerMap,
             boolean isGzipEnabled, String userAgent, String postText,
             UsernamePasswordCredentials credentials, boolean isSslValidationEnabled) throws
             ConnectionException {
@@ -115,8 +115,10 @@ public final class NetworkConnectionImpl {
             }
 
             StringBuilder paramBuilder = new StringBuilder();
-            if (parameterMap != null && !parameterMap.isEmpty()) {
-                for (BasicNameValuePair parameter : parameterMap) {
+            if (parameterList != null && !parameterList.isEmpty()) {
+                int parameterListLength = parameterList.size();
+                for (int i=0;i<parameterListLength;i++) {
+                    BasicNameValuePair parameter = parameterList.get(i);
                     paramBuilder.append(URLEncoder.encode(parameter.getName(), UTF8_CHARSET));
                     paramBuilder.append("=");
                     paramBuilder.append(URLEncoder.encode(parameter.getValue(), UTF8_CHARSET));
@@ -129,9 +131,11 @@ public final class NetworkConnectionImpl {
                 DataDroidLog.d(TAG, "Request url: " + urlValue);
                 DataDroidLog.d(TAG, "Method: " + method.toString());
 
-                if (parameterMap != null && !parameterMap.isEmpty()) {
+                if (parameterList != null && !parameterList.isEmpty()) {
                     DataDroidLog.d(TAG, "Parameters:");
-                    for (BasicNameValuePair parameter : parameterMap) {
+                    int parameterListLength = parameterList.size();
+                    for (int i=0;i<parameterListLength;i++) {
+                        BasicNameValuePair parameter = parameterList.get(i);
                         String message = "- " + parameter.getName() + " = " + parameter.getValue();
                         DataDroidLog.d(TAG, message);
                     }

--- a/DataDroid/src/com/foxykeep/datadroid/network/NetworkConnection.java
+++ b/DataDroid/src/com/foxykeep/datadroid/network/NetworkConnection.java
@@ -15,7 +15,9 @@ import com.foxykeep.datadroid.internal.network.NetworkConnectionImpl;
 import com.foxykeep.datadroid.util.DataDroidLog;
 
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.message.BasicNameValuePair;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +56,7 @@ public final class NetworkConnection {
     private final Context mContext;
     private final String mUrl;
     private Method mMethod = Method.GET;
-    private HashMap<String, String> mParameterMap = null;
+    private List<BasicNameValuePair> mParameterMap = null;
     private HashMap<String, String> mHeaderMap = null;
     private boolean mIsGzipEnabled = true;
     private String mUserAgent = null;
@@ -105,13 +107,36 @@ public final class NetworkConnection {
      * @see #setPostText(String)
      * @param parameterMap The parameters to add to the request.
      * @return The networkConnection.
+     * 
+     * @deprecated Use {@link #setParameters(List)}
      */
+    @Deprecated
     public NetworkConnection setParameters(HashMap<String, String> parameterMap) {
-        mParameterMap = parameterMap;
-        mPostText = null;
-        return this;
+        List<BasicNameValuePair> parameterList = new ArrayList<BasicNameValuePair>();
+        for (Map.Entry<String, String> entry : parameterMap.entrySet()) {
+          parameterList.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
+        }
+
+        return setParameters(parameterList);
     }
 
+
+    /**
+     * Set the parameters to add to the request. This is meant to be a "key" => "value" Map.
+     * <p>
+     * The POSTDATA text will be reset as they cannot be used at the same time.
+     *
+     * @see #setPostText(String)
+     * @param parameterMap The parameters to add to the request.
+     * @return The networkConnection.
+     * 
+     */
+    public NetworkConnection setParameters(List<BasicNameValuePair> parameterList) {
+      mParameterMap = parameterList;
+      mPostText = null;
+      return this;
+    }
+    
     /**
      * Set the headers to add to the request.
      *
@@ -183,6 +208,7 @@ public final class NetworkConnection {
      */
     public NetworkConnection setSslValidationEnabled(boolean enabled) {
         mIsSslValidationEnabled = enabled;
+        
         return this;
     }
 

--- a/DataDroid/src/com/foxykeep/datadroid/network/NetworkConnection.java
+++ b/DataDroid/src/com/foxykeep/datadroid/network/NetworkConnection.java
@@ -56,7 +56,7 @@ public final class NetworkConnection {
     private final Context mContext;
     private final String mUrl;
     private Method mMethod = Method.GET;
-    private List<BasicNameValuePair> mParameterMap = null;
+    private ArrayList<BasicNameValuePair> mParameterList = null;
     private HashMap<String, String> mHeaderMap = null;
     private boolean mIsGzipEnabled = true;
     private String mUserAgent = null;
@@ -105,14 +105,12 @@ public final class NetworkConnection {
      * The POSTDATA text will be reset as they cannot be used at the same time.
      *
      * @see #setPostText(String)
+     * @see #setParameters(ArrayList)
      * @param parameterMap The parameters to add to the request.
      * @return The networkConnection.
-     * 
-     * @deprecated Use {@link #setParameters(List)}
      */
-    @Deprecated
     public NetworkConnection setParameters(HashMap<String, String> parameterMap) {
-        List<BasicNameValuePair> parameterList = new ArrayList<BasicNameValuePair>();
+        ArrayList<BasicNameValuePair> parameterList = new ArrayList<BasicNameValuePair>();
         for (Map.Entry<String, String> entry : parameterMap.entrySet()) {
           parameterList.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
         }
@@ -125,14 +123,16 @@ public final class NetworkConnection {
      * Set the parameters to add to the request. This is meant to be a "key" => "value" Map.
      * <p>
      * The POSTDATA text will be reset as they cannot be used at the same time.
+     * <p>
+     * This method allows you to have multiple values for a single key in contrary to the HashMap version of the method ({@link #setParameters(HashMap)})
      *
      * @see #setPostText(String)
-     * @param parameterMap The parameters to add to the request.
+     * @see #setParameters(HashMap)
+     * @param parameterList The parameters to add to the request.
      * @return The networkConnection.
-     * 
      */
-    public NetworkConnection setParameters(List<BasicNameValuePair> parameterList) {
-      mParameterMap = parameterList;
+    public NetworkConnection setParameters(ArrayList<BasicNameValuePair> parameterList) {
+      mParameterList = parameterList;
       mPostText = null;
       return this;
     }
@@ -185,7 +185,7 @@ public final class NetworkConnection {
     public NetworkConnection setPostText(String postText) {
         mPostText = postText;
         mMethod = Method.POST;
-        mParameterMap = null;
+        mParameterList = null;
         return this;
     }
 
@@ -207,8 +207,7 @@ public final class NetworkConnection {
      * @return The networkConnection.
      */
     public NetworkConnection setSslValidationEnabled(boolean enabled) {
-        mIsSslValidationEnabled = enabled;
-        
+        mIsSslValidationEnabled = enabled;        
         return this;
     }
 
@@ -218,7 +217,7 @@ public final class NetworkConnection {
      * @return The result of the webservice call.
      */
     public ConnectionResult execute() throws ConnectionException {
-        return NetworkConnectionImpl.execute(mContext, mUrl, mMethod, mParameterMap,
+        return NetworkConnectionImpl.execute(mContext, mUrl, mMethod, mParameterList,
                 mHeaderMap, mIsGzipEnabled, mUserAgent, mPostText, mCredentials,
                 mIsSslValidationEnabled);
     }


### PR DESCRIPTION
It transforms mParameterMap to a List<BasicNameValuePair>, deprecating previous

``` java
com.foxykeep.datadroid.network.NetworkConnection

setParameters(HashMap<String,String> parameters)
```

in favor of

``` java
com.foxykeep.datadroid.network.NetworkConnection

setParameters(List<BasicNameValuePair> parameters)
```
