### PR TITLE
Fixes nginx returning "HTTP 411 Length Required" when sending a PUT request

### DIFF
--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -201,7 +201,7 @@ public final class NetworkConnectionImpl {
             connection.setConnectTimeout(OPERATION_TIMEOUT);
             connection.setReadTimeout(OPERATION_TIMEOUT);
 
-            // Set the outputStream content for POST requests
+            // Set the outputStream content for POST and PUT requests
             if ((method == Method.POST || method == Method.PUT) && outputText != null) {
                 OutputStream output = null;
                 try {

--- a/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
+++ b/DataDroid/src/com/foxykeep/datadroid/internal/network/NetworkConnectionImpl.java
@@ -21,6 +21,7 @@ import com.foxykeep.datadroid.util.DataDroidLog;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.protocol.HTTP;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -159,10 +160,10 @@ public final class NetworkConnectionImpl {
             switch (method) {
                 case GET:
                 case DELETE:
+                  url = new URL(urlValue + "?" + paramBuilder.toString());
+                  connection = (HttpURLConnection) url.openConnection();
+                  break;
                 case PUT:
-                    url = new URL(urlValue + "?" + paramBuilder.toString());
-                    connection = (HttpURLConnection) url.openConnection();
-                    break;
                 case POST:
                     url = new URL(urlValue);
                     connection = (HttpURLConnection) url.openConnection();
@@ -171,6 +172,7 @@ public final class NetworkConnectionImpl {
                     if (paramBuilder.length() > 0) {
                         outputText = paramBuilder.toString();
                         headerMap.put(CONTENT_TYPE_HEADER, "application/x-www-form-urlencoded");
+                        headerMap.put(HTTP.CONTENT_LEN, String.valueOf(outputText.getBytes().length));
                     } else if (postText != null) {
                         outputText = postText;
                     }
@@ -200,7 +202,7 @@ public final class NetworkConnectionImpl {
             connection.setReadTimeout(OPERATION_TIMEOUT);
 
             // Set the outputStream content for POST requests
-            if (method == Method.POST && outputText != null) {
+            if ((method == Method.POST || method == Method.PUT) && outputText != null) {
                 OutputStream output = null;
                 try {
                     output = connection.getOutputStream();


### PR DESCRIPTION
Nginx servers return "411 Length Required" under 3 circumstances

_client sent invalid "Content-Length" header
client sent ... method without "Content-Length" header
client sent "Transfer-Encoding: chunked" header_

(Post by Igor Sysoev, nginx author http://www.ruby-forum.com/topic/162976#715758. Several other sources by googling)

Currently NetworkConnectionImpl.java creates PUT requests as GET or DELETE requests, that is, it appends all the parameters to the url and omits the Content-Length header.

This pull request constructs PUT requests as a POST, placing the parameters in the body. Also, I've added the Content-Length header to both PUT and POST requests.

If for any reason you prefer to keep PUT parameters in the url, this is a simpler fix

``` java
if(method == Method.PUT)
  headerMap.put(HTTP.CONTENT_LEN, String.valueOf(0));
```

So you may consider to ignore this pull request and add that snippet somewhere inside _execute_
